### PR TITLE
Eloquent expects attribute to be string

### DIFF
--- a/src/JSON.php
+++ b/src/JSON.php
@@ -73,7 +73,7 @@ class JSON extends MergeValue
         if (is_string($attribute)) {
             $this->attribute = $attribute;
         } else {
-            $this->attribute = Str::of($name)
+            $this->attribute = (string) Str::of($name)
                 ->lower()
                 ->replace(' ', '_');
         }


### PR DESCRIPTION
Eloquent expects attribute to be string (e.g. array_key_exists in HasAttributes::hasCast())